### PR TITLE
Subaru Stop and Go support for both Global and Pre-Global platforms

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -155,13 +155,7 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
 
   if (!relay_malfunction) {
     if (bus_num == 0) {
-      //int addr = GET_ADDR(to_fwd);
-      // Global platform
-      // 0x390 Dashlights
-      //int block_msg = (addr == 0x390));
-      //if (!block_msg) {
-        bus_fwd = 2;  // Camera CAN
-      //}
+      bus_fwd = 2;  // Camera CAN
     }
     if (bus_num == 2) {
       // Global platform

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -9,7 +9,7 @@ const int SUBARU_DRIVER_TORQUE_ALLOWANCE = 60;
 const int SUBARU_DRIVER_TORQUE_FACTOR = 10;
 const int SUBARU_STANDSTILL_THRSLD = 20;  // about 1kph
 
-const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}, {0x390, 0, 8}, {0x40, 2, 8}};
+const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}, {0x390, 0, 8}, {0x40, 2, 8}, {0x139, 2, 8}};
 const int SUBARU_TX_MSGS_LEN = sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]);
 
 AddrCheckStruct subaru_rx_checks[] = {
@@ -157,8 +157,9 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
   if (!relay_malfunction) {
     if (bus_num == 0) {
       // Global platform
-      // 0x40 Throttle
-      int block_msg = ((addr == 0x40));
+      // 0x40 Throttle (for EPB Subaru SnG resume)
+      // 0x139 Break_Pedal (for NON-EPB Subaru support and SnG)
+      int block_msg = ((addr == 0x40) || (addr == 0x139));
       if (!block_msg) {
         bus_fwd = 2;  // Camera CAN
       }

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -9,7 +9,7 @@ const int SUBARU_DRIVER_TORQUE_ALLOWANCE = 60;
 const int SUBARU_DRIVER_TORQUE_FACTOR = 10;
 const int SUBARU_STANDSTILL_THRSLD = 20;  // about 1kph
 
-const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}};
+const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}, {0x390, 0, 8}};
 const int SUBARU_TX_MSGS_LEN = sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]);
 
 AddrCheckStruct subaru_rx_checks[] = {
@@ -155,7 +155,13 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
 
   if (!relay_malfunction) {
     if (bus_num == 0) {
-      bus_fwd = 2;  // Camera CAN
+      //int addr = GET_ADDR(to_fwd);
+      // Global platform
+      // 0x390 Dashlights
+      //int block_msg = (addr == 0x390));
+      //if (!block_msg) {
+        bus_fwd = 2;  // Camera CAN
+      //}
     }
     if (bus_num == 2) {
       // Global platform

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -9,7 +9,7 @@ const int SUBARU_DRIVER_TORQUE_ALLOWANCE = 60;
 const int SUBARU_DRIVER_TORQUE_FACTOR = 10;
 const int SUBARU_STANDSTILL_THRSLD = 20;  // about 1kph
 
-const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}, {0x390, 0, 8}};
+const CanMsg SUBARU_TX_MSGS[] = {{0x122, 0, 8}, {0x221, 0, 8}, {0x322, 0, 8}, {0x390, 0, 8}, {0x40, 2, 8}};
 const int SUBARU_TX_MSGS_LEN = sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]);
 
 AddrCheckStruct subaru_rx_checks[] = {
@@ -155,7 +155,11 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
 
   if (!relay_malfunction) {
     if (bus_num == 0) {
-      bus_fwd = 2;  // Camera CAN
+      int addr = GET_ADDR(to_fwd);
+      int block_msg = ((addr == 0x40));
+      if (!block_msg) {
+        bus_fwd = 2;  // Camera CAN
+      }
     }
     if (bus_num == 2) {
       // Global platform

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -152,10 +152,12 @@ static int subaru_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
 static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
   int bus_fwd = -1;
+  int addr = GET_ADDR(to_fwd);
 
   if (!relay_malfunction) {
     if (bus_num == 0) {
-      int addr = GET_ADDR(to_fwd);
+      // Global platform
+      // 0x40 Throttle
       int block_msg = ((addr == 0x40));
       if (!block_msg) {
         bus_fwd = 2;  // Camera CAN
@@ -166,7 +168,6 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       // 0x122 ES_LKAS
       // 0x221 ES_Distance
       // 0x322 ES_LKAS_State
-      int addr = GET_ADDR(to_fwd);
       int block_msg = ((addr == 0x122) || (addr == 0x221) || (addr == 0x322));
       if (!block_msg) {
         bus_fwd = 0;  // Main CAN

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -10,7 +10,7 @@ const int SUBARU_L_DRIVER_TORQUE_FACTOR = 10;
 const int SUBARU_L_STANDSTILL_THRSLD = 20;  // about 1kph
 const uint32_t SUBARU_L_BRAKE_THRSLD = 2; // filter sensor noise, max_brake is 400
 
-const CanMsg SUBARU_L_TX_MSGS[] = {{0x161, 0, 8}, {0x164, 0, 8}};
+const CanMsg SUBARU_L_TX_MSGS[] = {{0x161, 0, 8}, {0x164, 0, 8}, {0x140, 2, 8}};
 const int SUBARU_L_TX_MSGS_LEN = sizeof(SUBARU_L_TX_MSGS) / sizeof(SUBARU_L_TX_MSGS[0]);
 
 // TODO: do checksum and counter checks after adding the signals to the outback dbc file
@@ -142,16 +142,21 @@ static int subaru_legacy_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
 static int subaru_legacy_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
   int bus_fwd = -1;
-
+  int addr = GET_ADDR(to_fwd);
+  
   if (!relay_malfunction) {
     if (bus_num == 0) {
-      bus_fwd = 2;  // Camera CAN
+      // PreGlobal platform
+      // 0x140 Throttle
+      int block_msg = ((addr == 0x140));
+      if (!block_msg) {
+        bus_fwd = 2;  // Camera CAN
+      }
     }
     if (bus_num == 2) {
       // Preglobal platform
       // 0x161 is ES_CruiseThrottle
       // 0x164 is ES_LKAS
-      int addr = GET_ADDR(to_fwd);
       int block_msg = ((addr == 0x161) || (addr == 0x164));
       if (!block_msg) {
         bus_fwd = 0;  // Main CAN


### PR DESCRIPTION
Stop and Go by sending a "throttle tap" message to ES to resume ACC and get out of HOLD. SnG logic is done by checking Close_Distance.

Changes to PANDA: Intercept and Modify Throttle message, to allow for "Throttle tap" message to ES

Tested on
 - Subaru Impreza 2021 - global
 - Subaru Outback 2018 - pre-global
 - Subaru Outback 2019 - pre-global