### PR TITLE
Re-enable stock LKAS when OP is disengaged. (OP enabled, ACC off) 

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -160,7 +160,7 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       // 0x40 Throttle
       // 0x139 Brake_Pedal
       int block_msg = ((addr == 0x40) || (addr == 0x139));
-      if (!block_msg) {
+      if (!block_msg || !controls_allowed) {
         bus_fwd = 2;  // Camera CAN
       }
     }
@@ -170,7 +170,7 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       // 0x221 ES_Distance
       // 0x322 ES_LKAS_State
       int block_msg = ((addr == 0x122) || (addr == 0x221) || (addr == 0x322));
-      if (!block_msg) {
+      if (!block_msg || !controls_allowed) {
         bus_fwd = 0;  // Main CAN
       }
     }

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -90,6 +90,13 @@ static int subaru_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   int tx = 1;
   int addr = GET_ADDR(to_send);
 
+  if (!controls_allowed) {
+    tx = 0;
+  }
+  if (addr == 0x221) {
+    tx = 1;
+  }
+  
   if (!msg_allowed(to_send, SUBARU_TX_MSGS, SUBARU_TX_MSGS_LEN)) {
     tx = 0;
   }

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -303,6 +303,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
         if bus in self.FWD_BLACKLISTED_ADDRS and addr in self.FWD_BLACKLISTED_ADDRS[bus]:
           fwd_bus = -1
+        self.safety.set_controls_allowed(1)
         self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg))
 
   def test_spam_can_buses(self):

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -78,11 +78,11 @@ class TestSubaruSafety(common.PandaSafetyTest):
     self._rx(self._torque_driver_msg(max_t))
 
   def test_steer_safety_check(self):
-    for enabled in [0, 1]:
+    for enabled in [0,1]:
       for t in range(-3000, 3000):
         self.safety.set_controls_allowed(enabled)
         self._set_prev_torque(t)
-        block = abs(t) > MAX_STEER or (not enabled and abs(t) > 0)
+        block = (abs(t) > MAX_STEER) or not enabled
         self.assertEqual(not block, self._tx(self._torque_msg(t)))
 
   def test_non_realtime_limit_up(self):


### PR DESCRIPTION


I tried looking through the selfdrive/car/subaru.
I started implementing the tx_hook portion in carcontroller but then realized that it was not where the cancel command for ACC was coming from. It's probably in a common file but for now I'm driving this modified panda that re-enables forwarding of the stock LKAS while the OP is disengaged. 

The Subaru_safety file now controls the flow of stock LKAS and OP ALC to ensure they are separate. 
The ES_Distance message is the only exception allowed. ES_Distance can still be sent by OP when 
Ideally this should be able to be blocked as well but the Cancel command from pressing the gas got rejected and I haven't located that part of the code to see why it comes in that order on the gas pedal.

Otherwise, Safety_subaru swaps OP allowed to tx with the blacklist disabled to guarantee separation.   

Testing changes are: 
1. only assert blacklist while enabled (also it seems the test was previously only checking the blacklist while OP was disabled?)
2. assert that torque message is not allowed to be sent even with "0" torque when op is disengaged. (i do not know if this is used for something but, it's disengaged so it should not be injecting messages, right?

Everything works as expected. 
Stock LKAS is active when OP is disengaged. 
Gas and brake cancel OP and stock ACC. 


